### PR TITLE
✨ Add 'x' key vim motion to delete character under cursor in SQL editor

### DIFF
--- a/docs/dev/tasks.txt
+++ b/docs/dev/tasks.txt
@@ -12,6 +12,7 @@ So there is something called cargo binstall. This installs the prebuilt binaries
 =======================================
 =======================================
 =======================================
+DONE:
 In the SQL Editor we have VIM modes active. In that VIM mode I want you to implement pressing X in normal mode to delete the character under cursor.
 
 =======================================

--- a/src/app/handlers/query_editor.rs
+++ b/src/app/handlers/query_editor.rs
@@ -95,6 +95,12 @@ pub(crate) async fn handle(app: &mut App, key: KeyEvent) -> Result<()> {
         KeyCode::Char('G') => {
             app.state.query_editor.move_to_file_end();
         }
+        // 'x' - Delete character under cursor (vim motion)
+        KeyCode::Char('x') => {
+            app.state.query_editor.delete_char_under_cursor();
+            app.state.query_content = app.state.query_editor.get_content().to_string();
+            app.state.ui.query_modified = true;
+        }
         // ':' - Enter command mode
         KeyCode::Char(':') => {
             app.state.query_editor.enter_command_mode();

--- a/src/ui/help.rs
+++ b/src/ui/help.rs
@@ -659,6 +659,13 @@ impl HelpSystem {
         Self::add_command(lines, "g/G", "File start/File end (gg for start)");
         lines.push(Line::from(""));
 
+        lines.push(Line::from(vec![
+            Span::styled("  ✂️ ", Style::default().fg(Color::Red)),
+            Span::raw("Text Deletion (Normal Mode):"),
+        ]));
+        Self::add_command(lines, "x", "Delete character under cursor");
+        lines.push(Line::from(""));
+
         // Insert Mode Features
         lines.push(Line::from(vec![Span::styled(
             "✏️ Insert Mode Features",


### PR DESCRIPTION
Implements standard vim 'x' key functionality in the Query Editor's normal mode to delete the character at the cursor position. Also updates the help system documentation to reflect this new keybinding.